### PR TITLE
Feature/bootstrap callbacks

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -38,10 +38,10 @@ class Environment {
 
 	/**
 	 * Queue $callback for calling after the Environment is bootstrapped.
-	 * 
+	 *
 	 * If the environment is already bootstrapped, $callback is called immediately.
 	 *
-	 * @param callable $callback
+	 * @param callable $callback Callable to run after bootstrapping.
 	 * @return void
 	 */
 	public static function addBootstrapCallback(callable $callback): void {

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -122,4 +122,36 @@ class Environment {
 	public function envVar(string $name): mixed {
 		return getenv($name);
 	}
+
+	/**
+	 * Store a temporary value that needs to persist between requests.
+	 *
+	 * @throws EnvironmentException When this function is called without being implemented.
+	 * @param string  $name                   Name to recall this value by.
+	 * @param mixed   $value                  Value to store.
+	 * @param integer $secondsUntilExpiration Keep the value for up to this many seconds.
+	 * @return void
+	 */
+	public function setTransient(string $name, mixed $value, int $secondsUntilExpiration): void {
+		throw new EnvironmentException(
+			environment: self::$singleton,
+			message: 'setTransient was called without being implemented.'
+		);
+	}
+
+	/**
+	 * Get a transient value if it exists.
+	 *
+	 * @throws EnvironmentException When this function is called without being implemented.
+	 * @param string $name Name of the transient.
+	 * @return mixed Stored value; null if not found or expired.
+	 */
+	public function getTransientValue(string $name): mixed {
+		throw new EnvironmentException(
+			environment: self::$singleton,
+			message: 'getTransientValue was called without being implemented.'
+		);
+
+		return null;
+	}
 }

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -29,8 +29,21 @@ class Environment {
 	 */
 	private static ?Environment $singleton = null;
 
+	/**
+	 * Callbacks to call after the environment is bootstrapped.
+	 *
+	 * @var array
+	 */
 	private static $callAfterBootstrap = [];
 
+	/**
+	 * Queue $callback for calling after the Environment is bootstrapped.
+	 * 
+	 * If the environment is already bootstrapped, $callback is called immediately.
+	 *
+	 * @param callable $callback
+	 * @return void
+	 */
 	public static function addBootstrapCallback(callable $callback): void {
 		if (!self::$singleton) {
 			self::$callAfterBootstrap[] = $callback;

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -29,6 +29,18 @@ class Environment {
 	 */
 	private static ?Environment $singleton = null;
 
+	private static $callAfterBootstrap = [];
+
+	public static function addBootstrapCallback(callable $callback): void {
+		if (!self::$singleton) {
+			self::$callAfterBootstrap[] = $callback;
+			return;
+		}
+
+		// If we are already bootstrapped, then just run the function.
+		$callback();
+	}
+
 	/**
 	 * Load the given Environment as the current Environment.
 	 *
@@ -45,6 +57,10 @@ class Environment {
 		}
 
 		self::$singleton = $withEnvironment;
+
+		foreach (self::$callAfterBootstrap as $callback) {
+			$callback();
+		}
 	}
 
 	/**

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -43,4 +43,29 @@ final class EnvironmentTest extends TestCase {
 		Environment::bootstrap(new Environment());
 		Environment::get()->getHelperForModel('Model\\Class');
 	}
+
+	// https://stackoverflow.com/questions/9296529/phpunit-how-to-test-if-callback-gets-called
+	public function testItCanBeGivenACallbackBeforeBootstrapping(): void {
+		$called = false;
+		Environment::addBootstrapCallback(function() use (&$called) {
+			$called = true;
+		});
+
+		$this->assertFalse($called, 'Callback should not be called yet.');
+
+		Environment::bootstrap(new Environment());
+
+		$this->assertTrue($called, 'Callback should be called');
+	}
+
+	public function testItWillRunACallbackImmediatelyIfAlreadyBootstrapped(): void {
+		Environment::bootstrap(new Environment());
+
+		$called = false;
+		Environment::addBootstrapCallback(function() use (&$called) {
+			$called = true;
+		});
+
+		$this->assertTrue($called, 'Callback should be called');
+	}
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -68,4 +68,22 @@ final class EnvironmentTest extends TestCase {
 
 		$this->assertTrue($called, 'Callback should be called');
 	}
+
+	public function testItThrowsAnExceptionWhenSetTransientIsNotImplemented(): void {
+		$this->expectException(EnvironmentException::class);
+
+		Environment::bootstrap(new Environment());
+		Environment::get()->setTransient(
+			name: 'tempTransient',
+			value: 'tempValue',
+			secondsUntilExpiration: 1,
+		);
+	}
+
+	public function testItThrowsAnExceptionWhenGetTransientValueIsNotImplemented(): void {
+		$this->expectException(EnvironmentException::class);
+
+		Environment::bootstrap(new Environment());
+		Environment::get()->getTransientValue('tempTransient');
+	}
 }


### PR DESCRIPTION
Add a callback for bootstrapping plugins and such after the environment has been set.

Has nothing at all to do with WordPress' `add_action('init')` why do you ask?