### PR TITLE
Cu 86785qyy5 c2pa support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "smolblog/activitypub-types": "^1.0",
     "illuminate/database": "^9.0",
     "taproot/micropub-adapter": "^0.1.1",
-    "psr/log": "^3.0"
+    "psr/log": "^3.0",
+    "elephox/mimey": "^4.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26e0e38f4a558d2a6617dcef3bb1c481",
+    "content-hash": "9f414e0be43adaaeb3737a99ae00c3c8",
     "packages": [
         {
             "name": "brick/math",
@@ -351,6 +351,60 @@
                 }
             ],
             "time": "2023-06-16T13:40:37+00:00"
+        },
+        {
+            "name": "elephox/mimey",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elephox-dev/mimey.git",
+                "reference": "2b5910b3b35613feb47436d392f857e87183fcc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elephox-dev/mimey/zipball/2b5910b3b35613feb47436d392f857e87183fcc9",
+                "reference": "2b5910b3b35613feb47436d392f857e87183fcc9",
+                "shasum": ""
+            },
+            "require": {
+                "jetbrains/phpstorm-attributes": "^1.0",
+                "php": "^8.1 <8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-mbstring": "For non-English (user) input parsing"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Elephox\\Mimey\\": [
+                        "src/",
+                        "dist/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                },
+                {
+                    "name": "Ricardo Boss",
+                    "email": "contact@ricardoboss.de"
+                }
+            ],
+            "description": "PHP package for converting file extensions to MIME types and vice versa.",
+            "support": {
+                "issues": "https://github.com/elephox-dev/mimey/issues",
+                "source": "https://github.com/elephox-dev/mimey/tree/4.0.5"
+            },
+            "time": "2023-02-21T14:45:43+00:00"
         },
         {
             "name": "fig/event-dispatcher-util",
@@ -909,6 +963,48 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2023-06-11T21:11:53+00:00"
+        },
+        {
+            "name": "jetbrains/phpstorm-attributes",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JetBrains/phpstorm-attributes.git",
+                "reference": "a7a83ae5df4dd3c0875484483de19de8edf60a9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-attributes/zipball/a7a83ae5df4dd3c0875484483de19de8edf60a9f",
+                "reference": "a7a83ae5df4dd3c0875484483de19de8edf60a9f",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JetBrains\\PhpStorm\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "JetBrains",
+                    "homepage": "https://www.jetbrains.com"
+                }
+            ],
+            "description": "PhpStorm specific attributes",
+            "keywords": [
+                "attributes",
+                "jetbrains",
+                "phpstorm"
+            ],
+            "support": {
+                "issues": "https://youtrack.jetbrains.com/newIssue?project=WI",
+                "source": "https://github.com/JetBrains/phpstorm-attributes/tree/1.0"
+            },
+            "time": "2020-11-17T11:09:47+00:00"
         },
         {
             "name": "liamdennehy/http-signatures-php",

--- a/src/ContentProvenance/Action.php
+++ b/src/ContentProvenance/Action.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Smolblog\ContentProvenance;
+
+use Smolblog\Framework\Objects\Value;
+
+/**
+ * Describes an action recorded in a ProvinanceManifest.
+ */
+class Action extends Value {
+	/**
+	 * Create the Action.
+	 *
+	 * @param string      $type        Type of action taken.
+	 * @param string|null $description Optional description of the action taken.
+	 */
+	public function __construct(
+		public readonly string $type,
+		public readonly ?string $description = null,
+	) {
+	}
+
+	/**
+	 * Serialize this action.
+	 *
+	 * @return array
+	 */
+	public function toArray(): array {
+		$arr = ['action' => $this->type];
+		if (isset($this->description)) {
+			$arr['description'] = $this->description;
+		}
+
+		return $arr;
+	}
+}

--- a/src/ContentProvenance/Actions/Published.php
+++ b/src/ContentProvenance/Actions/Published.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Smolblog\ContentProvenance\Actions;
+
+use Smolblog\ContentProvenance\Action;
+
+/**
+ * Describes that the content was published (uploaded to Smolblog).
+ */
+class Published extends Action {
+	/**
+	 * Create the action.
+	 *
+	 * @param string|null $description Optional description.
+	 */
+	public function __construct(
+		?string $description = null
+	) {
+		parent::__construct(type: 'c2pa.published', description: $description);
+	}
+}

--- a/src/ContentProvenance/ContentProvenanceEnvironment.php
+++ b/src/ContentProvenance/ContentProvenanceEnvironment.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Smolblog\ContentProvenance;
+
+/**
+ * Environment information needed by the ContentProvenance module.
+ */
+interface ContentProvenanceEnvironment {
+	/**
+	 * Full path to the c2patool executable.
+	 *
+	 * @return string
+	 */
+	public function getPathToC2patool(): string;
+}

--- a/src/ContentProvenance/InvalidManifestException.php
+++ b/src/ContentProvenance/InvalidManifestException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Smolblog\ContentProvenance;
+
+use Exception;
+use Smolblog\Framework\Exceptions\SmolblogException;
+
+/**
+ * Indicates a Manifest was created with invalid values.
+ */
+class InvalidManifestException extends Exception implements SmolblogException {
+}

--- a/src/ContentProvenance/ManifestService.php
+++ b/src/ContentProvenance/ManifestService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Smolblog\ContentProvenance;
+
+class ManifestService {
+
+}

--- a/src/ContentProvenance/ManifestService.php
+++ b/src/ContentProvenance/ManifestService.php
@@ -2,6 +2,67 @@
 
 namespace Smolblog\ContentProvenance;
 
-class ManifestService {
+use Crell\Tukio\Listener;
+use Psr\Log\LoggerInterface;
+use Smolblog\ContentProvenance\Actions\Published;
+use Smolblog\Core\Content\Media\HandleUploadedMedia;
+use Smolblog\Core\Content\Media\MediaService;
+use Smolblog\Core\Content\Media\MediaType;
+use Smolblog\Framework\Messages\Attributes\ExecutionLayerListener;
 
+/**
+ * Service that intercepts an uploaded file command and attaches a manifest to it.
+ */
+class ManifestService extends Listener {
+	/**
+	 * Create the service.
+	 *
+	 * @param ContentProvenanceEnvironment $env  Environment with the c2patool path.
+	 * @param LoggerInterface              $logs PSR-3 logger.
+	 */
+	public function __construct(
+		private ContentProvenanceEnvironment $env,
+		private LoggerInterface $logs,
+	) {
+	}
+
+	/**
+	 * Apply the given Manifest to the media file at the given path.
+	 *
+	 * @param ProvenanceManifest $manifest    Manifest to apply.
+	 * @param string             $pathToMedia Path to the media file to apply the manifest to.
+	 * @return void
+	 */
+	public function applyManifest(ProvenanceManifest $manifest, string $pathToMedia) {
+		$toolPath = $this->env->getPathToC2patool();
+		$manifestJson = str_replace("'", "\\'", json_encode($manifest));
+		$result = shell_exec("$toolPath '$pathToMedia' --config '$manifestJson' --output '$pathToMedia' --force");
+
+		if (!$result) {
+			$this->logs->error("Could not apply manifest", [
+				'manifest' => $manifest->toArray(),
+				'pathToMedia' => $pathToMedia,
+			]);
+		}
+	}
+
+	/**
+	 * Apply a Published manifest to an uploaded file.
+	 *
+	 * This edits the temporary file in-place so further services can handle the file in their own ways.
+	 *
+	 * @param HandleUploadedMedia $command Command to execute.
+	 * @return void
+	 */
+	#[ExecutionLayerListener(earlier: 5)]
+	public function onHandleUploadedMedia(HandleUploadedMedia $command) {
+		if (MediaService::typeFromMimeType($command->file->getClientMediaType() ?? '') === MediaType::File) {
+			return;
+		}
+
+		$this->applyManifest(
+			manifest: new ProvenanceManifest(actions: [new Published()]),
+			pathToMedia: $command->file->getStream()->getMetadata('uri'),
+		);
+	}
 }

--- a/src/ContentProvenance/Model.php
+++ b/src/ContentProvenance/Model.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Smolblog\ContentProvenance;
+
+use Psr\Log\LoggerInterface;
+use Smolblog\Framework\Objects\DomainModel;
+
+/**
+ * Domain model for Content Provenance and Authenticity.
+ */
+class Model extends DomainModel {
+	public const SERVICES = [
+		ManifestService::class => [
+			'env' => ContentProvenanceEnvironment::class,
+			'logs' => LoggerInterface::class,
+		],
+	];
+}

--- a/src/ContentProvenance/Model.php
+++ b/src/ContentProvenance/Model.php
@@ -2,6 +2,7 @@
 
 namespace Smolblog\ContentProvenance;
 
+use Elephox\Mimey\MimeTypesInterface;
 use Psr\Log\LoggerInterface;
 use Smolblog\Framework\Objects\DomainModel;
 
@@ -12,6 +13,7 @@ class Model extends DomainModel {
 	public const SERVICES = [
 		ManifestService::class => [
 			'env' => ContentProvenanceEnvironment::class,
+			'mimes' => MimeTypesInterface::class,
 			'logs' => LoggerInterface::class,
 		],
 	];

--- a/src/ContentProvenance/ProvenanceManifest.php
+++ b/src/ContentProvenance/ProvenanceManifest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Smolblog\ContentProvenance;
+
+use Smolblog\Framework\Objects\Value;
+
+/**
+ * A C2PA Manifest, used to track changes.
+ */
+class ProvenanceManifest extends Value {
+	/**
+	 * Construct the Manifest.
+	 *
+	 * @throws InvalidManifestException If valid parameters are not given.
+	 *
+	 * @param Action[] $actions Actions taken at this time; at least 1 is required.
+	 */
+	public function __construct(
+		public readonly array $actions,
+	) {
+		if (empty($actions)) {
+			throw new InvalidManifestException('At least one Action is required.');
+		}
+		if (!empty(array_filter($actions, fn($a) => !is_a($a, Action::class)))) {
+			throw new InvalidManifestException('$actions should only contain Actions.');
+		}
+	}
+
+	/**
+	 * Serialize the Manifest.
+	 *
+	 * @return array
+	 */
+	public function toArray(): array {
+	$arr = [
+			'ta_url' => 'http://timestamp.digicert.com',
+			'claim_generator' => 'Smolblog/0.1',
+			'assertions' => [
+				[
+					'label' => 'c2pa.actions',
+					'data' => [
+						'actions' => array_map(fn($a) => $a->toArray(), $this->actions),
+					],
+				],
+			],
+		];
+
+		return $arr;
+	}
+}


### PR DESCRIPTION
Add a middleware to uploaded images to sign them with a C2PA manifest. This provides a chain of custody for the image, showing that it was uploaded to the server at this date and time.

Requires the C2PA Tool to be installed.

The tool requires a file extension on the file, so it is temporarily renamed to its original file name or a generated filename before it is moved back to its temporary location. This allows the subsequent MediaHandler to do what it will with the file without having to change the existing process too much.

A further exercise might involve adding author/user information and/or storing the full manifest in a projection. But this is here now.